### PR TITLE
Overhaul CACHEF

### DIFF
--- a/cachef.lisp
+++ b/cachef.lisp
@@ -1,0 +1,167 @@
+(in-package #:place-utils)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; CACHEF - macro
+
+(defmacro cachef (&whole cachef-form
+                    cachedp-place cache-place init-form
+		              &key test new-cachedp init-form-evaluates-to)
+  (declare (ignore cachedp-place cache-place init-form
+		               test new-cachedp init-form-evaluates-to))
+  `(readf ,cachef-form))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; CACHEF - main SETF expander body
+
+(define-setf-expander cachef (cachedp-place cache-place init-form
+		                          &key (test ''identity)
+			                          (init-form-evaluates-to :value)
+			                          (new-cachedp t new-cachedp-p)
+		                          &environment env)
+  (let ((cache-expansion (multiple-value-list (get-setf-expansion
+                                               cache-place env))))
+    (when (cdr (third cache-expansion))
+	    (error 'a:simple-program-error
+             :format-control "CACHE-PLACE must involve only one value."))
+    (cond (cachedp-place
+	         ;; Out-of-cache cachedp (OOCC) mode.
+	         (let ((cachedp-expansion (multiple-value-list (get-setf-expansion
+                                                          cachedp-place env))))
+             (when (cdr (third cachedp-expansion))
+	             (error 'a:simple-program-error
+                      :format-control
+                      "CACHEDP-PLACE must involve only one value."))
+             (expand-oocc-place cache-expansion cachedp-expansion
+                                init-form init-form-evaluates-to
+                                test new-cachedp)))
+          (t
+           ;; In-cache cachedp (ICC) mode.
+           (when new-cachedp-p
+             (error 'a:simple-program-error
+                    :format-control
+                    "It's an error to provide :NEW-CACHEDP when CACHE-PLACE~@
+                     doubles as the CACHEDP-PLACE. Presumably (but not ~@
+                     necessarily) the values of INIT-FORM will satisfy TEST ~@
+                     next time.~@
+                     The value of :NEW-CACHEDP wrongly provided is: ~%~S"
+                    :format-arguments (list new-cachedp)))
+	         (expand-icc-place cache-expansion init-form
+                             init-form-evaluates-to test)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; CACHEF - OOCC branch, main body
+
+(defun expand-oocc-place (cache-expansion cachedp-expansion
+                          init-form init-form-evaluates-to
+                          test-value new-cachedp-value)
+  (a:with-gensyms (new-cachedp test init-function)
+    (let* ((init-function (ecase init-form-evaluates-to
+			                      (:value nil)
+			                      (:function init-function)))
+           ;; Return values
+           (vars (oocc-generate-vars cache-expansion cachedp-expansion
+                                     init-function new-cachedp test))
+           (vals (oocc-generate-vals cache-expansion cachedp-expansion
+                                     init-function init-form
+                                     new-cachedp-value test-value))
+           (stores (third cache-expansion))
+           (writer (oocc-generate-writer cache-expansion cachedp-expansion
+                                         new-cachedp test))
+           (reader (oocc-generate-reader cache-expansion cachedp-expansion
+                                         init-function init-form
+                                         new-cachedp test)))
+	    (values vars vals stores writer reader))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; CACHEF - OOCC branch, generating return values
+
+(defun oocc-generate-vars (cache-expansion cachedp-expansion init-function
+                           new-cachedp-var test-var)
+  `(,@(first cache-expansion)
+    ,@(first cachedp-expansion)
+	  ,@(when init-function (list init-function))
+    ,test-var ,new-cachedp-var))
+
+(defun oocc-generate-vals (cache-expansion cachedp-expansion init-function
+                           init-form new-cachedp test)
+  `(,@(second cache-expansion)
+    ,@(second cachedp-expansion)
+		,@(when init-function (list init-form))
+    ,test ,new-cachedp))
+
+(defun oocc-generate-caching (cache-writer cachedp-stores
+                              cachedp-writer new-cachedp-var)
+  `(prog1 ,cache-writer
+		 (let ((,(car cachedp-stores) ,new-cachedp-var))
+			 ,cachedp-writer)))
+
+(defun oocc-generate-writer (cache-expansion cachedp-expansion
+                             new-cachedp-var test-var)
+  (let ((cache-writer (fourth cache-expansion)))
+    (destructuring-bind (cachedp-stores cachedp-reader cachedp-writer)
+        (cddr cachedp-expansion)
+      `(if (funcall ,test-var ,cachedp-reader)
+			     ,cache-writer
+           ,(oocc-generate-caching cache-writer cachedp-stores
+                                   cachedp-writer new-cachedp-var)))))
+
+(defun oocc-generate-reader (cache-expansion cachedp-expansion
+                             init-function init-form
+                             new-cachedp-var test-var)
+  (destructuring-bind (cache-stores cache-writer cache-reader)
+      (cddr cache-expansion)
+    (destructuring-bind (cachedp-stores cachedp-writer cachedp-reader)
+        (cddr cachedp-expansion)
+      (let ((evaluate-init-form (if init-function
+                                    `(funcall ,init-function)
+                                    init-form)))
+        `(if (funcall ,test-var ,cachedp-reader)
+		         ,cache-reader
+		         (let ((,(car cache-stores) ,evaluate-init-form))
+			         ,(oocc-generate-caching cache-writer cachedp-stores
+                                       cachedp-writer new-cachedp-var)))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; CACHEF - ICC branch, main body
+
+(defun expand-icc-place (cache-expansion init-form
+                         init-form-evaluates-to test-value)
+  (a:with-gensyms (test init-function)
+    (let* ((init-function (ecase init-form-evaluates-to
+			                      (:value nil)
+			                      (:function init-function)))
+	         (evaluate-init-form (if init-function
+				                           `(funcall ,init-function)
+				                           init-form))
+           (vars (icc-generate-vars cache-expansion init-function
+                                    test))
+           (vals (icc-generate-vals cache-expansion init-function
+                                    init-form test-value))
+           (stores (third cache-expansion))
+           (writer (fourth cache-expansion))
+           (reader (icc-generate-reader cache-expansion evaluate-init-form
+                                        test)))
+      (values vars vals stores writer reader))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; CACHEF - ICC branch, generating return values
+
+(defun icc-generate-vars (cache-expansion init-function test-var)
+  `(,@(first cache-expansion)
+		,@(when init-function (list init-function))
+		,test-var))
+
+(defun icc-generate-vals (cache-expansion init-function init-form test)
+  `(,@(second cache-expansion)
+		,@(when init-function (list init-form))
+		,test))
+
+(defun icc-generate-reader (cache-expansion evaluate-init-form test-var)
+  (destructuring-bind (cache-stores cache-writer cache-reader)
+      (cddr cache-expansion)
+    (a:with-gensyms (cache-var)
+      `(let ((,cache-var ,cache-reader))
+		     (if (funcall ,test-var ,cache-var)
+			       ,cache-var
+			       (let ((,(car cache-stores) ,evaluate-init-form))
+				       ,cache-writer))))))

--- a/main.lisp
+++ b/main.lisp
@@ -235,108 +235,15 @@
 	     (setf ,new-var (funcall ,on-replace-var ,old-var ,new-var))
 	     ,writer))))))
 
-(define-setf-expander cachef (cachedp-place
-			      cache-place
-			      init-form
-			      &rest key-args
-			      &key test
-			      (init-form-evaluates-to :value)
-			      (new-cachedp t new-cachedp-sp)
-			      &environment env)
-  (let* ((test (or test '#'identity))
-	 (test-var (gensym "TEST"))
-	 (init-form-function (ecase init-form-evaluates-to
-			       (:value nil)
-			       (:function (gensym "INIT-FORM-FUNCTION"))))
-	 (evaluate-init-form (if init-form-function
-				 `(funcall ,init-form-function)
-				 init-form)))
-    (multiple-value-bind (cache-vars cache-values cache-stores
-			  cache-writer cache-reader)
-	(get-setf-expansion cache-place env)
-      (when (cdr cache-stores)
-	(error "cache-place must involve only one value."))
-      (if cachedp-place
-	  ;; Out-of-cache cachedp (OOCC) mode.
-	  (multiple-value-bind (cachedp-vars cachedp-values cachedp-stores
-				cachedp-writer cachedp-reader)
-	      (get-setf-expansion cachedp-place env)
-	    (when (cdr cachedp-stores)
-	      (error "cachedp-place must involve only one value."))
-	    (let* ((new-cachedp-var (gensym "NEW-CACHEDP"))
-		   (do-caching
-		       `(prog1 ,cache-writer
-			  (let ((,(car cachedp-stores) ,new-cachedp-var))
-			    ,cachedp-writer)))
-		   (correct-order
-		    (ecase (do ((key-args key-args (cddr key-args)))
-			       ((null key-args) :test)
-			     (let ((key (car key-args)))
-			       (when (member key '(:test :new-cachedp))
-				 (return key))))
-		      (:test #'identity)
-		      (:new-cachedp #'nreverse))))
-	      (values `(,@cache-vars
-			,@cachedp-vars
-			,@(when init-form-function
-			    (list init-form-function))
-			,@(funcall correct-order
-				   (list test-var new-cachedp-var)))
-		      `(,@cache-values
-			,@cachedp-values
-			,@(when init-form-function
-			    (list init-form))
-			,@(funcall correct-order
-				   (list test new-cachedp)))
-		      cache-stores
-		      `(if (funcall ,test-var ,cachedp-reader)
-			   ,cache-writer
-			   ,do-caching)
-		      `(if (funcall ,test-var ,cachedp-reader)
-			   ,cache-reader
-			   (let ((,(car cache-stores) ,evaluate-init-form))
-			     ,do-caching)))))
-	  ;; In-cache cachedp (ICC) mode.
-	  (if new-cachedp-sp
-	      (error "It's an error to provide :NEW-CACHEDP~@
-                      when CACHE-PLACE doubles as the CACHEDP-PLACE.~@
-                      Presumably (but not necessarily) the values of INIT-FORM ~
-                      will satisfy TEST next time.~@
-                      The value of :NEW-CACHEDP wrongly provided is: ~%~S"
-		     new-cachedp)
-	      (let ((cache-value (gensym "CACHE-VALUE")))
-		(values `(,@cache-vars
-			  ,@(when init-form-function
-			      (list init-form-function))
-			  ,test-var)
-			`(,@cache-values
-			  ,@(when init-form-function
-			      (list init-form))
-			  ,test)
-			cache-stores
-			cache-writer
-			`(let ((,cache-value ,cache-reader))
-			   (if (funcall ,test-var ,cache-value)
-			       ,cache-value
-			       (let ((,(car cache-stores) ,evaluate-init-form))
-				 ,cache-writer))))))))))
-
-(defmacro cachef (&whole cachef-form
-		  cachedp-place cache-place init-form
-		  &key test new-cachedp init-form-evaluates-to)
-  (declare (ignore cachedp-place cache-place init-form
-		   test new-cachedp init-form-evaluates-to))
-  `(readf ,cachef-form))
-
 (define-setf-expander oldf (place &environment env)
   (multiple-value-bind (subvars subforms stores writer reader)
       (get-setf-expansion place env)
     (values subvars
-	    subforms
-	    stores
-	    `(multiple-value-prog1 ,reader
-	       ,writer)
-	    reader)))
+      subforms
+      stores
+      `(multiple-value-prog1 ,reader
+         ,writer)
+      reader)))
 
 (defmacro oldf (&whole whole place)
   (declare (ignore place))
@@ -346,14 +253,14 @@
   (multiple-value-bind (vars values stores writer reader)
       (get-setf-expansion place env)
     (flet ((fmt (action control-string &rest format-args)
-	     `(format *trace-output*
-		      "~&TRACEF: Place: ~S~@
+       `(format *trace-output*
+          "~&TRACEF: Place: ~S~@
                        TRACEF: Action: ~A~@
                        ~A~2%"
-		      ',place ,action
-		      (format nil ,control-string ,@format-args))))
+          ',place ,action
+          (format nil ,control-string ,@format-args))))
       (let ((result (gensym "RESULT")))
-	(values vars
+  (values vars
 		(mapcar
 		 (lambda (value)
 		   `(let ((,result ,value))

--- a/package.lisp
+++ b/package.lisp
@@ -2,11 +2,12 @@
 
 (defpackage #:place-utils
   (:use #:cl)
+  (:local-nicknames (#:a #:alexandria))
   (:export #:setf-expanderlet
-	   #:with-resolved-places
-	   #:updatef
-	   #:bulkf
-	   #:cachef
-	   #:oldf
-	   #:readf
-	   #:tracef))
+           #:with-resolved-places
+           #:updatef
+           #:bulkf
+           #:cachef
+           #:oldf
+           #:readf
+           #:tracef))

--- a/place-utils.asd
+++ b/place-utils.asd
@@ -8,7 +8,9 @@
 
   :version "0.2"
   :serial cl:t
+  :depends-on (#:alexandria)
   :components ((:file "package")
-	       (:file "main"))
+               (:file "main")
+               (:file "cachef"))
 
   :in-order-to ((asdf:test-op (asdf:test-op #:place-utils_tests))))

--- a/tests/cachef.lisp
+++ b/tests/cachef.lisp
@@ -1,0 +1,351 @@
+(cl:in-package #:place-utils_tests)
+
+(define-test "CACHEF")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; CACHEF - test utilities
+
+(defvar *result*)
+
+(defun loudcar (cons &optional cachedp)
+  (push (if cachedp :cachedp-read :place-read) *result*)
+  (car cons))
+
+(defun (setf loudcar) (newval cons &optional cachedp)
+  (push (if cachedp :cachedp-written :place-written) *result*)
+  (setf (car cons) newval))
+
+(defun verify (expected)
+  (is equal expected (nreverse *result*))
+  (setf *result* '()))
+
+(defun make-empty-adjustable-string ()
+  (make-array 0 :element-type 'character :fill-pointer t :adjustable t))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; CACHEF - examples
+
+(define-test "CACHEF-EXAMPLE-ICC"
+  :parent "CACHEF"
+  (flet ((perform (initial-value)
+           (let ((cache initial-value)
+                 (output (make-empty-adjustable-string)))
+             (with-output-to-string (*standard-output* output)
+               (incf (cachef nil cache 0 :test #'numberp) (princ (+ 5 2)))
+               (list cache output)))))
+    (is equal '(7 "7") (perform "cached-string"))
+    (is equal '(27 "7") (perform 20))))
+
+(define-test "CACHEF-EXAMPLE-OOCC"
+  :parent "CACHEF"
+  (let ((values (list :empty :placeholder))
+        (output (make-empty-adjustable-string)))
+    (flet ((fullp (marker) (ecase marker (:full t) (:empty nil))))
+      (with-output-to-string (*standard-output* output)
+        (cachef (first values) (second (prin1 values)) :computed-value
+                :test #'fullp :new-cachedp :full)
+        (is equal '((:full :computed-value) "(:EMPTY :PLACEHOLDER)")
+            (list values output))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; CACHEF - basic tests
+
+(define-test "CACHEF-ICC-BASIC"
+  :parent "CACHEF"
+  (macrolet ((perform (place newval expected &rest cachef-args)
+               (a:with-gensyms (result)
+                 `(let ((,result (cachef nil ,place ,newval ,@cachef-args)))
+                    (is equal ,expected ,result)
+                    (is equal ,expected ,place)))))
+    ;; Simple check with #'IDENTITY.
+    (let ((x nil))
+      (perform x :foo :foo)
+      (perform x :bar :foo))
+    ;; Simple check with #'IDENTITY and function init-form.
+    (let ((x nil))
+      (perform x (lambda () :foo) :foo :init-form-evaluates-to :function)
+      (perform x (lambda () :bar) :foo :init-form-evaluates-to :function))
+    ;; Simple check with #'ODDP and mixed init-forms.
+    (let ((x 0))
+      (perform x 2 2 :test #'oddp)
+      (perform x (lambda () 4) 4 :test #'oddp :init-form-evaluates-to :function)
+      (perform x 5 5 :test #'oddp)
+      (perform x (lambda () 6) 5 :test #'oddp :init-form-evaluates-to :function)
+      (perform x 8 5 :test #'oddp)
+      (perform x (lambda () 9) 5 :test #'oddp :init-form-evaluates-to :function)
+      (perform x 10 5 :test #'oddp))))
+
+(define-test "CACHEF-OOCC-BASIC"
+  :parent "CACHEF"
+  (macrolet ((perform (cachedp-place place newval expected &rest cachef-args)
+               (a:with-gensyms (result)
+                 `(let ((,result (cachef ,cachedp-place ,place ,newval
+                                         ,@cachef-args)))
+                    (is equal ,expected ,result)
+                    (is equal ,expected ,place)))))
+    ;; Simple check with #'IDENTITY.
+    (let ((x nil)
+          (cachedp nil))
+      (perform cachedp x :foo :foo)
+      (perform cachedp x :bar :foo)
+      (setf cachedp nil)
+      (perform cachedp x :bar :bar))
+    ;; Simple check with #'IDENTITY and function init-form.
+    (let ((x nil)
+          (cachedp nil))
+      (perform cachedp x (lambda () :foo) :foo
+               :init-form-evaluates-to :function)
+      (perform cachedp x (lambda () :bar) :foo
+               :init-form-evaluates-to :function)
+      (setf cachedp nil)
+      (perform cachedp x (lambda () :bar) :bar
+               :init-form-evaluates-to :function))
+    ;; Simple check with set :NEW-CACHEDP, declared types, and mixed init-forms.
+    (let ((x 0)
+          (cachedp nil))
+      (declare (type integer x)
+               (type boolean cachedp))
+      (perform cachedp x 2 2 :new-cachedp nil)
+      (perform cachedp x (lambda () 4) 4 :new-cachedp nil
+                                         :init-form-evaluates-to :function)
+      (perform cachedp x 5 5 :new-cachedp t)
+      (perform cachedp x (lambda () 6) 5 :new-cachedp t
+                                         :init-form-evaluates-to :function)
+      (perform cachedp x 8 5 :new-cachedp t)
+      (perform cachedp x (lambda () 9) 5 :new-cachedp t
+                                         :init-form-evaluates-to :function)
+      (perform cachedp x 10 5 :new-cachedp t))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; CACHEF - evaluation order test
+
+(define-test "CACHEF-ICC-EVALUATION-ORDER-VALUE-INIT-FORM"
+  :parent "CACHEF"
+  (let ((*result* '())
+        (x (cons nil nil)))
+    (flet ((perform (expected)
+             (cachef nil (loudcar x) (progn (push :init-form *result*) 42)
+                     :test (progn
+                             (push :test-returned *result*)
+                             (lambda (x) (push :test-called *result*) x)))
+             (verify expected)))
+      ;; Expected order:
+      ;; 1. Evaluate the test form to produce the test function.
+      ;; 2. Read the initial value of the place.
+      ;; 3. Call the test function on the initial value of the place.
+      ;; 4. Evaluate the init form to produce the new initial value.
+      ;; 5. Write the new value of the place.
+      (perform '(:test-returned :place-read :test-called
+                 :init-form :place-written))
+      ;; Expected order:
+      ;; 1. Evaluate the test form to produce the test function.
+      ;; 2. Read the modified value of the place.
+      ;; 3. Call the test function on the modified value of the place.
+      (perform '(:test-returned :place-read :test-called)))))
+
+(define-test "CACHEF-ICC-EVALUATION-ORDER-FUNCTION-INIT-FORM"
+  :parent "CACHEF"
+  (let ((*result* '())
+        (x (cons nil nil)))
+    (flet ((perform (expected)
+             (cachef nil (loudcar x)
+                     (lambda () (progn (push :init-function *result*) 42))
+                     :test (progn (push :test-returned *result*)
+                                  (lambda (x) (push :test-called *result*) x))
+                     :init-form-evaluates-to :function)
+             (verify expected)))
+      ;; Expected order:
+      ;; 1. Evaluate the test form to produce the test function.
+      ;; 2. Read the initial value of the place.
+      ;; 3. Call the test function on the initial value of the place.
+      ;; 4. Call the init function to produce the new initial value.
+      ;; 5. Write the new value of the place.
+      (perform '(:test-returned :place-read :test-called
+                 :init-function :place-written))
+      ;; Expected order:
+      ;; 1. Evaluate the test form to produce the test function.
+      ;; 2. Read the modified value of the place.
+      ;; 3. Call the test function on the modified value of the place.
+      (perform '(:test-returned :place-read :test-called)))))
+
+(define-test "CACHEF-OOCC-EVALUATION-ORDER-VALUE-INIT-FORM"
+  :parent "CACHEF"
+  (let ((*result* '())
+        (x (cons nil nil))
+        (y (cons nil nil)))
+    (flet ((perform (expected)
+             (cachef (loudcar y t) (loudcar x)
+                     (progn (push :init-form *result*) 42)
+                     :test (progn
+                             (push :test-returned *result*)
+                             (lambda (x) (push :test-called *result*) x)))
+             (verify expected)))
+      ;; Expected order:
+      ;; 1. Evaluate the test form to produce the test function.
+      ;; 2. Read the initial value of the cache.
+      ;; 3. Call the test function on the initial value of the place.
+      ;; 4. Evaluate the init form to produce the new initial value.
+      ;; 5. Write the new value of the place.
+      ;; 6. Write the new value of the cache.
+      (perform '(:test-returned :cachedp-read :test-called
+                 :init-form :place-written :cachedp-written))
+      ;; Expected order:
+      ;; 1. Evaluate the test form to produce the test function.
+      ;; 2. Read the modified value of the cache.
+      ;; 3. Call the test function on the modified value of the place.
+      ;; 4. Read the modified value of the place.
+      (perform '(:test-returned :cachedp-read :test-called :place-read)))))
+
+(define-test "CACHEF-OOCC-EVALUATION-ORDER-FUNCTION-INIT-FORM"
+  :parent "CACHEF"
+  (let ((*result* '())
+        (x (cons nil nil))
+        (y (cons nil nil)))
+    (flet ((perform (expected)
+             (cachef (loudcar y t) (loudcar x)
+                     (lambda () (progn (push :init-function *result*) 42))
+                     :test (progn (push :test-returned *result*)
+                                  (lambda (x) (push :test-called *result*) x))
+                     :init-form-evaluates-to :function)
+             (verify expected)))
+      ;; Expected order:
+      ;; 1. Evaluate the test form to produce the test function.
+      ;; 2. Read the initial value of the cache.
+      ;; 3. Call the test function on the initial value of the place.
+      ;; 4. Call the init function to produce the new initial value.
+      ;; 5. Write the new value of the place.
+      ;; 5. Write the new value of the cache.
+      (perform '(:test-returned :cachedp-read :test-called
+                 :init-function :place-written :cachedp-written))
+      ;; Expected order:
+      ;; 1. Evaluate the test form to produce the test function.
+      ;; 2. Read the modified value of the cache.
+      ;; 3. Call the test function on the modified value of the place.
+      ;; 4. Read the modified value of the place.
+      (perform '(:test-returned :cachedp-read :test-called :place-read)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; CACHEF - error tests
+
+(define-test "CACHEF-ERROR"
+  :parent "CACHEF"
+  ;; CACHE-PLACE must involve only one value.
+  (fail (macroexpand '(cachef nil (values foo bar baz) 42)) program-error)
+  ;; CACHEDP-PLACE must involve only one value.
+  (fail (macroexpand '(cachef (values foo bar baz) quux 42)) program-error)
+  ;; :NEW-CACHEDP must not be provided in ICC mode.
+  (fail (macroexpand '(cachef nil foo bar :new-cachedp t)) program-error))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; CACHEF - internal tests - utilities
+
+(defun equal* (x y)
+  (cond ((and (symbolp x) (null (symbol-package x))
+              (symbolp y) (null (symbol-package y)))
+         (string= x y))
+        ((and (consp x) (consp y))
+         (and (equal* (car x) (car y))
+              (equal* (cdr x) (cdr y))))
+        (t (equal x y))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; CACHEF - internal tests
+
+(define-test "CACHEF-INTERNAL")
+
+(define-test "CACHEF-INTERNAL-ICC-VALUE-INIT-FORM"
+  :parent "CACHEF-INTERNAL"
+  (let ((*gensym-counter* 0)
+        (expansion '((#:foo #:bar) (42 24) (#:new) (#:writer) (#:reader)))
+        (init-form '(#:init-form))
+        (test '#:test))
+    (multiple-value-bind (vars vals stores writer reader)
+        (place-utils::expand-icc-place expansion init-form :value test)
+      (is equal* '(#:foo #:bar #:test0) vars)
+      (is equal* '(42 24 #:test) vals)
+      (is equal* '(#:new) stores)
+      (is equal* '(#:writer) writer)
+      (let ((expected-reader '(let ((#:cache-var2 (#:reader)))
+                               (if (funcall #:test0 #:cache-var2)
+                                   #:cache-var2
+                                   (let ((#:new (#:init-form)))
+                                     (#:writer))))))
+        (is equal* expected-reader reader)))))
+
+(define-test "CACHEF-INTERNAL-ICC-FUNCTION-INIT-FORM"
+  :parent "CACHEF-INTERNAL"
+  (let ((*gensym-counter* 0)
+        (expansion '((#:foo #:bar) (42 24) (#:new) (#:writer) (#:reader)))
+        (init-form '(#:init-form))
+        (test '#:test))
+    (multiple-value-bind (vars vals stores writer reader)
+        (place-utils::expand-icc-place expansion init-form :function test)
+      (is equal* '(#:foo #:bar #:init-function1 #:test0) vars)
+      (is equal* '(42 24 (#:init-form) #:test) vals)
+      (is equal* '(#:new) stores)
+      (is equal* '(#:writer) writer)
+      (let ((expected-reader `(let ((#:cache-var2 (#:reader)))
+                                (if (funcall #:test0 #:cache-var2)
+                                    #:cache-var2
+                                    (let ((#:new (funcall #:init-function1)))
+                                      (#:writer))))))
+        (is equal* expected-reader reader)))))
+
+(define-test "CACHEF-INTERNAL-OOCC-VALUE-INIT-FORM"
+  :parent "CACHEF-INTERNAL"
+  (let ((*gensym-counter* 0)
+        (expansion-1 '((#:foo #:bar) (42 24) (#:new) (#:writer2) (#:reader2)))
+        (expansion-2 '((#:baz #:qux) (51 15) (#:old) (#:writer2) (#:reader2)))
+        (init-form '(#:init-form))
+        (test '#:test)
+        (new-cachedp '#:new-cachedp))
+    (multiple-value-bind (vars vals stores writer reader)
+        (place-utils::expand-oocc-place expansion-1 expansion-2
+                                        init-form :value test new-cachedp)
+      (is equal* '(#:foo #:bar #:baz #:qux #:test1 #:new-cachedp0)
+          vars)
+      (is equal* '(42 24 51 15 #:test #:new-cachedp) vals)
+      (is equal* '(#:new) stores)
+      (let ((expected-writer `(if (funcall #:test1 (#:writer2))
+                                  (#:writer2)
+                                  (prog1 (#:writer2)
+                                    (let ((#:old #:new-cachedp0))
+                                      (#:reader2))))))
+        (is equal* expected-writer writer))
+      (let ((expected-reader `(if (funcall #:test1 (#:reader2))
+                                  (#:reader2)
+                                  (let ((#:new (#:init-form)))
+                                    (prog1 (#:writer2)
+                                      (let ((#:old #:new-cachedp0))
+                                        (#:writer2)))))))
+        (is equal* expected-reader reader)))))
+
+(define-test "CACHEF-INTERNAL-OOCC-FUNCTION-INIT-FORM"
+  :parent "CACHEF-INTERNAL"
+  (let ((*gensym-counter* 0)
+        (expansion-1 '((#:foo #:bar) (42 24) (#:new) (#:writer2) (#:reader2)))
+        (expansion-2 '((#:baz #:qux) (51 15) (#:old) (#:writer2) (#:reader2)))
+        (init-form '(#:init-form))
+        (test '#:test)
+        (new-cachedp '#:new-cachedp))
+    (multiple-value-bind (vars vals stores writer reader)
+        (place-utils::expand-oocc-place expansion-1 expansion-2
+                                        init-form :function test new-cachedp)
+      (is equal* '(#:foo #:bar #:baz #:qux
+                   #:init-function2 #:test1 #:new-cachedp0)
+          vars)
+      (is equal* '(42 24 51 15 (#:init-form) #:test #:new-cachedp) vals)
+      (is equal* '(#:new) stores)
+      (let ((expected-writer `(if (funcall #:test1 (#:writer2))
+                                  (#:writer2)
+                                  (prog1 (#:writer2)
+                                    (let ((#:old #:new-cachedp0))
+                                      (#:reader2))))))
+        (is equal* expected-writer writer))
+      (let ((expected-reader `(if (funcall #:test1 (#:reader2))
+                                  (#:reader2)
+                                  (let ((#:new (funcall #:init-function2)))
+                                    (prog1 (#:writer2)
+                                      (let ((#:old #:new-cachedp0))
+                                        (#:writer2)))))))
+        (is equal* expected-reader reader)))))

--- a/tests/place-utils_tests.asd
+++ b/tests/place-utils_tests.asd
@@ -10,6 +10,7 @@
                "parachute")
 
   :serial cl:t
-  :components ((:file "tests"))
+  :components ((:file "tests")
+               (:file "cachef"))
 
   :perform (asdf:test-op (op c) (uiop:symbol-call '#:parachute '#:test '#:place-utils_tests)))

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -1,4 +1,5 @@
 (cl:defpackage #:place-utils_tests
+  (:local-nicknames (#:a #:alexandria))
   (:use #:cl #:place-utils #:parachute))
 
 (cl:in-package #:place-utils_tests)
@@ -65,7 +66,7 @@
              (initf 0 a b (second c))
              (values a b c)))))
   (flet ((bulkf-spread (spread-function sum-function
-                                        &rest place-values)
+                        &rest place-values)
            (values-list
             (let ((number-of-places (length place-values)))
               (make-list number-of-places
@@ -97,7 +98,7 @@
                0
                (:NOTHING-VALUABLE NIL 0))
        (flet ((bulkf-steal (sum-function steal-function
-                                         initial-assets &rest target-assets)
+                            initial-assets &rest target-assets)
                 (let (stolen leftovers)
                   (mapc (lambda (assets)
                           (multiple-value-bind (steal leftover)
@@ -123,27 +124,7 @@
                            (values assets (if (numberp assets) 0 nil))))
                      cave museum house (first triplex) (second triplex) (third triplex))
              (values cave museum house triplex)))))
-  (flet ((test (initial-value expected-result)
-           (are equal expected-result
-                (let ((cache initial-value)
-                      (output (make-array 0 :element-type 'character :fill-pointer t :adjustable t)))
-                  (with-output-to-string (*standard-output* output)
-                    (incf (cachef nil cache 0 :test #'numberp) (princ (+ 5 2)))
-                    (values cache output))))))
-    (test "cached-string" '(7 "7"))
-    (test 20 '(27 "7")))
-  (are equal '((:full :computed-value) "(:EMPTY :PLACEHOLDER)")
-       (let ((values (list :empty :placeholder))
-             (output (make-array 0 :element-type 'character :fill-pointer t :adjustable t)))
-         (with-output-to-string (*standard-output* output)
-           (cachef (first values) (second (prin1 values))
-                   :computed-value
-                   :test (lambda (marker)
-                           (ecase marker
-                             (:full t)
-                             (:empty nil)))
-                   :new-cachedp :full)
-           (values values output))))
+  ;; For CACHEF examples, see cachef.lisp
   (are equal '(5 7)
        (let ((a 5))
          (values (incf (oldf a) 2)


### PR DESCRIPTION
* `cachef` and its testware is exported into its own files.
* The implementation is split into separate functions as according to best programming practices.
* Tests are greatly improved, with 62 assertions for the API and 20 assertions for the internal functions.
* This commit introduces a dependency on Alexandria for `simple-program-error` and `with-gensyms`.

I hereby allow the full contents of this commit to go into the Unlicense and therefore disclaim any personal rights to it, including any copyrights.